### PR TITLE
Adding deploy config

### DIFF
--- a/controller/deploy.go
+++ b/controller/deploy.go
@@ -1,17 +1,19 @@
 package controller
 
-import (
-	"k8s.io/kubernetes/pkg/api"
-)
-
 // PaaSService defines what the handler expects from a service interacting with the PAAS
 type PaaSService interface {
-	CreateService(namespace, serviceName, selector, description string, port int32, labels map[string]string) (*api.Service, error)
-	CreateRoute(namespace, serviceToBindTo, appName, optionalHost string, labels map[string]string) error
-	CreateImageStream(namespace, name string, labels map[string]string) error
-	CreateSecret(namespace, name string) error
-	CreateBuildConfig(namespace, name, selector, description, gitURL, gitBranch string, labels map[string]string) error
-	CreateDeploymentConfig(namespace, name string) error
+	CreateService(dc DeployCmd, description string, port int32) error
+	CreateRoute(dc DeployCmd, optionalHost string) error
+	CreateImageStream(dc DeployCmd) error
+	CreateSecret(dc DeployCmd, data map[string][]byte) error
+	CreateBuildConfig(dc DeployCmd, description, fromNamespace, fromImageName string) error
+	CreateDeploymentConfig(dc DeployCmd, fromImage, description string) error
+}
+
+// EnvVar defines an environment variable
+type EnvVar struct {
+	Key   string `json:"key,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 type Deploy struct {
@@ -26,10 +28,11 @@ func NewDeployController(paaSService PaaSService) Deploy {
 
 // DeployCmd encapsulates what data is required to do a deploy
 type DeployCmd interface {
+	SetAppTag(string)
+	GetAppTag() string
+	Labels() map[string]string
+	AppName() string
 	EnvironmentName() string
-	CloudAppName() string
-	BuildConfigName() string
-	ServiceName() string
 	CloudAppGUID() string
 	Project() string
 	DomainName() string
@@ -37,6 +40,8 @@ type DeployCmd interface {
 	Authentication() string
 	SourceLoc() string
 	SourceBranch() string
+	GetEnvVars() []*EnvVar
+	AddEnvVar(name, value string)
 }
 
 type DeployResponse struct {
@@ -45,7 +50,7 @@ type DeployResponse struct {
 }
 
 func (d Deploy) Run(dc DeployCmd) (interface{}, error) {
-	exists, err := d.buildConfigExists(dc.BuildConfigName())
+	exists, err := d.buildConfigExists(dc.CloudAppGUID())
 	if err != nil {
 		return nil, err
 	}
@@ -60,26 +65,56 @@ func (d Deploy) buildConfigExists(name string) (bool, error) {
 }
 
 func (d Deploy) create(dc DeployCmd) (*DeployResponse, error) {
-	labels := map[string]string{
-		"rmmap/guid":    dc.CloudAppGUID(),
-		"rhmap/project": dc.Project(),
-		"rhmap/domain":  dc.DomainName(),
+	appTag := dc.GetAppTag()
+	if appTag == "" {
+		appTag = "cloud"
 	}
-	if _, err := d.paaSService.CreateService(dc.EnvironmentName(), dc.ServiceName(), dc.CloudAppName(), "rhmap cloud app", 8001, labels); err != nil {
+
+	dc.SetAppTag("redis")
+	d.createRedis(dc)
+	dc.AddEnvVar("REDIS_HOST", dc.AppName())
+	dc.SetAppTag(appTag)
+	return d.createCloudApp(dc)
+}
+
+func (d Deploy) createRedis(dc DeployCmd) error {
+	if err := d.paaSService.CreateService(dc, "redis app", 8001); err != nil {
+		return err
+	}
+	if err := d.paaSService.CreateDeploymentConfig(dc, "docker.io/rhmap/redis:2.18.22", "redis deployment config"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d Deploy) createCloudApp(dc DeployCmd) (*DeployResponse, error) {
+	if err := d.paaSService.CreateService(dc, "rhmap cloud app", 8001); err != nil {
 		return nil, err
 	}
-	if err := d.paaSService.CreateRoute(dc.EnvironmentName(), dc.ServiceName(), dc.CloudAppName(), "", labels); err != nil {
+	if err := d.paaSService.CreateRoute(dc, ""); err != nil {
 		return nil, err
 	}
-	if err := d.paaSService.CreateImageStream(dc.EnvironmentName(), dc.CloudAppName(), labels); err != nil {
+	if err := d.paaSService.CreateImageStream(dc); err != nil {
 		return nil, err
 	}
 	//create secrets
-
-	//create build config
-	if err := d.paaSService.CreateBuildConfig(dc.EnvironmentName(), dc.BuildConfigName(), dc.CloudAppName(), "rhmap cloud app", dc.SourceLoc(), dc.SourceBranch(), labels); err != nil {
+	if err := d.paaSService.CreateSecret(dc, map[string][]byte{
+		"username": []byte(dc.UserName()),
+		"password": []byte(dc.Authentication()),
+	}); err != nil {
 		return nil, err
 	}
+
+	//create build config
+	if err := d.paaSService.CreateBuildConfig(dc, "Build Config for RHMAP cloud app", "openshift", "nodejs:4"); err != nil {
+		return nil, err
+	}
+
+	if err := d.paaSService.CreateDeploymentConfig(dc, dc.AppName() + ":latest", "rhmap cloud app"); err != nil {
+		return nil, err
+	}
+
+	// TODO change to actual log URL
 	return &DeployResponse{Status: "inprogress", LogURL: "http://mybuildlogurl.com/url"}, nil
 }
 

--- a/domain/openshift/service.go
+++ b/domain/openshift/service.go
@@ -1,11 +1,14 @@
 package openshift
 
 import (
+	"github.com/feedhenry/negotiator/controller"
 	bc "github.com/openshift/origin/pkg/build/api"
 	bcv1 "github.com/openshift/origin/pkg/build/api/v1"
+	dcapi "github.com/openshift/origin/pkg/deploy/api"
 	ioapi "github.com/openshift/origin/pkg/image/api"
 	roapi "github.com/openshift/origin/pkg/route/api"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
@@ -18,6 +21,8 @@ type PaaSClient interface {
 	CreateRouteInNamespace(ns string, r *roapi.Route) (*roapi.Route, error)
 	CreateImageStream(ns string, i *ioapi.ImageStream) (*ioapi.ImageStream, error)
 	CreateBuildConfigInNamespace(namespace string, b *bc.BuildConfig) (*bc.BuildConfig, error)
+	CreateDeployConfigInNamespace(namespace string, d *dcapi.DeploymentConfig) (*dcapi.DeploymentConfig, error)
+	CreateSecretInNamespace(namespace string, s *api.Secret) (*api.Secret, error)
 }
 
 // Service encapsulates the domain logic for deploying our app to OpenShift
@@ -32,21 +37,29 @@ func NewService(client PaaSClient) Service {
 	}
 }
 
-// CreateRoute defines a route for a given cloud app
-func (s Service) CreateRoute(namespace, serviceToBindTo, appName, optionalHost string, labels map[string]string) error {
-	if nil == labels {
-		labels = map[string]string{}
+func formatEnvVars(dcEnvVars []*controller.EnvVar) []api.EnvVar {
+	envVars := []api.EnvVar{}
+	for _, envVar := range dcEnvVars {
+		envVars = append(envVars, api.EnvVar{Value: envVar.Value, Name: envVar.Key})
 	}
+	return envVars
+}
+
+// CreateRoute defines a route for a given cloud app
+func (s Service) CreateRoute(dc controller.DeployCmd, optionalHost string) error {
 	route := &roapi.Route{
 		ObjectMeta: api.ObjectMeta{
-			Name:   appName,
-			Labels: labels,
+			Name:   dc.AppName(),
+			Labels: dc.Labels(),
 		},
 		Spec: roapi.RouteSpec{
 			Host: optionalHost,
 			To: roapi.RouteTargetReference{
 				Kind: "Service",
-				Name: serviceToBindTo,
+				Name: dc.AppName(),
+			},
+			Port: &roapi.RoutePort{
+				TargetPort: intstr.FromString("web"),
 			},
 			TLS: &roapi.TLSConfig{
 				Termination:                   roapi.TLSTerminationEdge,
@@ -54,7 +67,7 @@ func (s Service) CreateRoute(namespace, serviceToBindTo, appName, optionalHost s
 			},
 		},
 	}
-	if _, err := s.client.CreateRouteInNamespace(namespace, route); err != nil {
+	if _, err := s.client.CreateRouteInNamespace(dc.EnvironmentName(), route); err != nil {
 		return err
 	}
 
@@ -62,15 +75,15 @@ func (s Service) CreateRoute(namespace, serviceToBindTo, appName, optionalHost s
 }
 
 // CreateService sets up a service via the Kubernetes API
-func (s Service) CreateService(namespace, serviceName, selector, description string, port int32, labels map[string]string) (*api.Service, error) {
+func (s Service) CreateService(dc controller.DeployCmd, description string, port int32) error {
 	serv := &api.Service{
 		ObjectMeta: api.ObjectMeta{
-			Name:   serviceName,
-			Labels: labels,
+			Name:   dc.AppName(),
+			Labels: dc.Labels(),
 			Annotations: map[string]string{
 				"rhmap/description": description,
-				"rhmap/title":       selector,
-				"description":       "round robin loadbalancer for your app",
+				"rhmap/title":       dc.AppName(),
+				"description":       "Service for " + dc.AppName(),
 			},
 		},
 		Spec: api.ServiceSpec{
@@ -82,89 +95,67 @@ func (s Service) CreateService(namespace, serviceName, selector, description str
 				},
 			},
 			Selector: map[string]string{
-				"name": selector,
+				"name": dc.AppName(),
 			},
 		},
 	}
-	retServ, err := s.client.CreateServiceInNamespace(namespace, serv)
-	if err != nil {
-		return nil, err
-	}
-
-	return retServ, nil
-}
-
-/**
-{
-        "kind": "ImageStream",
-        "apiVersion": "v1",
-        "metadata": {
-          "name": nodejsObjectsTitle,
-          "labels" : labels,
-          "annotations" : {
-            "rhmap/description" : description,
-            "rhmap/title" : title,
-            "description": "Keeps track of changes in the application image"
-          }
-        }
-      }
-
-*/
-// CreateImageStream setup an image stream for the cloud app
-func (s Service) CreateImageStream(namespace, name string, labels map[string]string) error {
-	is := &ioapi.ImageStream{
-		ObjectMeta: api.ObjectMeta{
-			Name:   name,
-			Labels: labels,
-			Annotations: map[string]string{
-				"rhmap/description": "image stream for tracking changes to your app",
-				"rhmap/title":       name,
-				"description":       "",
-			},
-		},
-	}
-	if _, err := s.client.CreateImageStream(namespace, is); err != nil {
+	if _, err := s.client.CreateServiceInNamespace(dc.EnvironmentName(), serv); err != nil {
 		return err
 	}
 	return nil
 }
 
-/**
-{
-    "apiVersion": "v1",
-    "kind": "Secret",
-    "type": "Opaque",
-    "metadata": {
-      "name": `${nodejsObjectsTitle}-scmsecret`,
-      "labels" : labels,
-      "annotations" : {
-        "rhmap/description" : description,
-        "rhmap/title" : title,
-        "description": "SSH keypair used to clone the application from a private repo"
-      }
-    }
-	"data":{
-		username:username,
-		password:password
+// CreateImageStream setup an image stream for the cloud app
+func (s Service) CreateImageStream(dc controller.DeployCmd) error {
+	is := &ioapi.ImageStream{
+		ObjectMeta: api.ObjectMeta{
+			Name:   dc.AppName(),
+			Labels: dc.Labels(),
+			Annotations: map[string]string{
+				"rhmap/description": "image stream for tracking changes to your app",
+				"rhmap/title":       dc.AppName(),
+				"description":       "",
+			},
+		},
 	}
-  }
- **/
-// CreateSecret creates a secret in the OSCP
-func (s Service) CreateSecret(namespace, name string) error {
+	if _, err := s.client.CreateImageStream(dc.EnvironmentName(), is); err != nil {
+		return err
+	}
+	return nil
+}
 
+// CreateSecret creates a secret in the OSCP
+func (s Service) CreateSecret(dc controller.DeployCmd, data map[string][]byte) error {
+	secret := &api.Secret{
+		ObjectMeta: api.ObjectMeta{
+			Name:   dc.AppName(),
+			Labels: dc.Labels(),
+			Annotations: map[string]string{
+				"rhmap/description": "SSH kepair used to clone the application from a private repo",
+				"rhmap/title":       dc.AppName(),
+				"description":       "SSH keypair used to clone the application from a private repo",
+			},
+		},
+		Data: data,
+		Type: api.SecretTypeOpaque,
+	}
+
+	if _, err := s.client.CreateSecretInNamespace(dc.EnvironmentName(), secret); err != nil {
+		return err
+	}
 	return nil
 }
 
 // CreateBuildConfig creates a buildconfig in the OSCP
-func (s Service) CreateBuildConfig(namespace, name, selector, description, gitUrl, gitBranch string, labels map[string]string) error {
+func (s Service) CreateBuildConfig(dc controller.DeployCmd, description, fromNamespace, fromImageName string) error {
 	bc := &bc.BuildConfig{
 		ObjectMeta: api.ObjectMeta{
-			Name:   name,
-			Labels: labels,
+			Name:   dc.AppName(),
+			Labels: dc.Labels(),
 			Annotations: map[string]string{
 				"rhmap/description": description,
-				"rhmap/title":       selector,
-				"description":       "round robin loadbalancer for your app",
+				"rhmap/title":       dc.AppName(),
+				"description":       "buildconfig for " + dc.AppName(),
 			},
 		},
 		Spec: bc.BuildConfigSpec{
@@ -172,32 +163,27 @@ func (s Service) CreateBuildConfig(namespace, name, selector, description, gitUr
 			CommonSpec: bc.CommonSpec{
 				Source: bc.BuildSource{
 					Git: &bc.GitBuildSource{
-						URI: gitUrl,
-						Ref: gitBranch,
+						URI: dc.SourceLoc(),
+						Ref: dc.SourceBranch(),
 					},
 					SourceSecret: &api.LocalObjectReference{
-						Name: name + "-scmsecret",
+						Name: dc.AppName(),
 					},
 				},
 				Strategy: bc.BuildStrategy{
 					SourceStrategy: &bc.SourceBuildStrategy{
 						From: api.ObjectReference{
 							Kind:      "ImageStreamTag",
-							Namespace: namespace,
-							Name:      selector + ":latest",
+							Namespace: fromNamespace,
+							Name:      fromImageName,
 						},
-						Env: []api.EnvVar{
-							{
-								Name:  "NODE_ENV",
-								Value: "production",
-							},
-						},
+						Env: formatEnvVars(dc.GetEnvVars()),
 					},
 				},
 				Output: bc.BuildOutput{
 					To: &api.ObjectReference{
 						Kind: "ImageStreamTag",
-						Name: name + ":latest",
+						Name: dc.AppName() + ":latest",
 					},
 				},
 			},
@@ -209,94 +195,89 @@ func (s Service) CreateBuildConfig(namespace, name, selector, description, gitUr
 		},
 	}
 
-	if _, err := s.client.CreateBuildConfigInNamespace(namespace, bc); err != nil {
+	if _, err := s.client.CreateBuildConfigInNamespace(dc.EnvironmentName(), bc); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// DeploymentConfig
-
-/**
-{
-        "kind": "DeploymentConfig",
-        "apiVersion": "v1",
-        "metadata": {
-          "name": nodejsObjectsTitle,
-          "labels" : labels,
-          "annotations" : {
-            "rhmap/description" : description,
-            "rhmap/title" : title,
-            "description": "Defines how to deploy the application server"
-          }
-        },
-        "spec": {
-          "strategy": {
-            "type": "Rolling"
-          },
-          "triggers": [
-            {
-              "type": "ImageChange",
-              "imageChangeParams": {
-                "automatic": true,
-                "containerNames": [
-                  nodejsObjectsTitle
-                ],
-                "from": {
-                  "kind": "ImageStreamTag",
-                  "name": `${nodejsObjectsTitle}:latest`
-                }
-              }
-            },
-            {
-              "type": "ConfigChange"
-            }
-          ],
-          "replicas": 1,
-          "selector": {
-            "name": nodejsObjectsTitle
-          },
-          "template": {
-            "metadata": {
-              "name": nodejsObjectsTitle,
-              "labels": {
-                "name": nodejsObjectsTitle,
-                "rhmap/env": labels["rhmap/env"],
-                "rhmap/guid": labels["rhmap/guid"],
-                "rhmap/domain": labels["rhmap/domain"],
-                "rhmap/project": labels["rhmap/project"]
-              }
-            },
-            "spec": {
-              "containers": [
-                {
-                  "name": nodejsObjectsTitle,
-                  "image": nodejsObjectsTitle,
-                  "ports": [
-                    {
-                      "containerPort": 8001
-                    }
-                  ],
-                  "env": formatEnvVarArray(params, redisServiceName),
-                  "resources": {
-                    "limits": {
-                      "cpu": "500m",
-                      "memory": "250Mi"
-                    },
-                    "requests": {
-                      "cpu": "100m",
-                      "memory": "90Mi"
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      }
-**/
 // CreateDeploymentConfig creates a deploymentconfig in the OSCP
-func (s Service) CreateDeploymentConfig(namespace, name string) error {
+func (s Service) CreateDeploymentConfig(dCmd controller.DeployCmd, fromImage, description string) error {
+	dc := &dcapi.DeploymentConfig{
+		ObjectMeta: api.ObjectMeta{
+			Name:   dCmd.AppName(),
+			Labels: dCmd.Labels(),
+			Annotations: map[string]string{
+				"rhmap/description": description,
+				"rhmap/title":       dCmd.AppName(),
+				"description":       "Deploy config for " + dCmd.AppName(),
+			},
+		},
+		Spec: dcapi.DeploymentConfigSpec{
+			Strategy: dcapi.DeploymentStrategy{
+				Type: dcapi.DeploymentStrategyTypeRolling,
+			},
+			Triggers: []dcapi.DeploymentTriggerPolicy{
+				{
+					Type: dcapi.DeploymentTriggerOnImageChange,
+					ImageChangeParams: &dcapi.DeploymentTriggerImageChangeParams{
+						Automatic: true,
+						ContainerNames: []string{
+							dCmd.AppName(),
+						},
+						From: api.ObjectReference{
+							Kind: "ImageStream",
+							Name: dCmd.AppName(),
+						},
+					},
+				},
+				{
+					Type: dcapi.DeploymentTriggerOnConfigChange,
+				},
+			},
+			Replicas: 1,
+			Selector: map[string]string{
+				"name": dCmd.AppName(),
+			},
+			Template: &api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Name: dCmd.AppName(),
+					Labels: map[string]string{
+						"name": dCmd.AppName(),
+					},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Name:  dCmd.AppName(),
+							Image: fromImage,
+							Ports: []api.ContainerPort{
+								{
+									ContainerPort: 8001,
+								},
+							},
+							Env: formatEnvVars(dCmd.GetEnvVars()),
+							Resources: api.ResourceRequirements{
+								Limits: api.ResourceList{
+									"cpu":    resource.MustParse("500m"),
+									"memory": resource.MustParse("250Mi"),
+								},
+								Requests: api.ResourceList{
+									"cpu":    resource.MustParse("100m"),
+									"memory": resource.MustParse("90Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := s.client.CreateDeployConfigInNamespace(dCmd.EnvironmentName(), dc); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -10,17 +10,10 @@ import (
 	"github.com/feedhenry/negotiator/config"
 	"github.com/feedhenry/negotiator/controller"
 	"github.com/feedhenry/negotiator/domain/openshift"
+	"github.com/feedhenry/negotiator/endpoint"
 	pkgos "github.com/feedhenry/negotiator/pkg/openshift"
 	"github.com/gorilla/mux"
 )
-
-// Logger describes an logging interface
-type Logger interface {
-	Info(args ...interface{})
-	Error(args ...interface{})
-}
-
-//this dependency building logic could endup being moved out of main.
 
 // Builds the openshift service that encapsulates logic for creating the objects via the pkg/client
 func buildPaasService() openshift.Service {
@@ -43,8 +36,8 @@ func buildSysHandler() SysHandler {
 	return SysHandler{}
 }
 
-func buildDeployHandler() DeployHandler {
-	return NewDeployHandler(logrus.StandardLogger(), buildDeployController(), &config.Conf{})
+func buildDeployHandler() endpoint.Deploy {
+	return endpoint.NewDeployHandler(logrus.StandardLogger(), buildDeployController(), &config.Conf{})
 }
 
 func buildHTTPHandler() http.Handler {

--- a/pkg/openshift/client.go
+++ b/pkg/openshift/client.go
@@ -7,6 +7,8 @@ import (
 	bc "github.com/openshift/origin/pkg/build/api"
 	bcv1 "github.com/openshift/origin/pkg/build/api/v1"
 	oclient "github.com/openshift/origin/pkg/client"
+	dc "github.com/openshift/origin/pkg/deploy/api"
+	dcv1 "github.com/openshift/origin/pkg/deploy/api/v1"
 	ioapi "github.com/openshift/origin/pkg/image/api"
 	ioapi1 "github.com/openshift/origin/pkg/image/api/v1"
 	roapi "github.com/openshift/origin/pkg/route/api"
@@ -51,6 +53,8 @@ func NewClient(conf clientcmd.ClientConfig) (Client, error) {
 
 	bc.AddToScheme(api.Scheme)
 	bcv1.AddToScheme(api.Scheme)
+	dc.AddToScheme(api.Scheme)
+	dcv1.AddToScheme(api.Scheme)
 	roapi.AddToScheme(api.Scheme)
 	roapi1.AddToScheme(api.Scheme)
 	ioapi.AddToScheme(api.Scheme)
@@ -114,6 +118,14 @@ func (c Client) CreateServiceInNamespace(ns string, svc *api.Service) (*api.Serv
 	return s, err
 }
 
+func (c Client) CreateSecretInNamespace(ns string, s *api.Secret) (*api.Secret, error) {
+	s, err := c.k8.Secrets(ns).Create(s)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create service")
+	}
+	return s, err
+}
+
 func (c Client) CreateRouteInNamespace(ns string, r *roapi.Route) (*roapi.Route, error) {
 	route, err := c.oc.Routes(ns).Create(r)
 	if err != nil {
@@ -137,4 +149,13 @@ func (c Client) CreateBuildConfigInNamespace(ns string, b *bc.BuildConfig) (*bc.
 		return nil, errors.Wrap(err, "failed to create BuildConfig")
 	}
 	return buildConfig, err
+}
+
+// CreateDeployConfigInNamespace creates the supplied deploy config in the supplied namespace and returns the deployconfig, or any errors that occurred
+func (c Client) CreateDeployConfigInNamespace(ns string, d *dc.DeploymentConfig) (*dc.DeploymentConfig, error) {
+	deployConfig, err := c.oc.DeploymentConfigs(ns).Create(d)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create DeployConfig")
+	}
+	return deployConfig, err
 }


### PR DESCRIPTION
This is just a proof of concept, still requires a generous application of polish.

## Supported:
- Cloning from public repos
- Cloning from private repos with username / password
- Passing in repo auth via request
- Creating a node.js application with an associated redis pod
- Assigning environment variables with REDIS_HOST to the node.js pod.
- Passing in environment variables via request

## Unsupported
- Specifying the from image of the node.js application (hard-coded as nodejs:4)
- Cloning from private repos with ssh key
- Returning a URL to track progress of deploy
- Input validation of any kind
- Ports for redis and node.js application are hard-coded
- Redeploying the same app
- Any unit testing