### PR TITLE
Rhmap 13738

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ install:
   - go get -v github.com/Masterminds/glide
   - cd $GOPATH/src/github.com/Masterminds/glide && git checkout bd55e763dbfac7b4684f6f3149bb56bed313175a
   - cd $HOME/gopath/src/github.com/feedhenry/negotiator
-  - glide install --strip-vendor
 script:
-  - make --keep-going ci
+  - make test-unit

--- a/pkg/mock/paasClient.go
+++ b/pkg/mock/paasClient.go
@@ -52,6 +52,21 @@ func (pc PassClient) GetDeploymentConfigByName(ns, deploymentName string) (*dcap
 
 }
 
+func (pc PassClient) CreatePersistentVolumeClaim(namespace string, claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {
+	pc.Called["CreatePersistentVolumeClaim"]++
+	if e, ok := pc.Error["CreatePersistentVolumeClaim"]; ok {
+		return nil, e
+	}
+	var ret = claim
+	if pc.Returns["CreatePersistentVolumeClaim"] != nil {
+		ret = pc.Returns["CreatePersistentVolumeClaim"].(*api.PersistentVolumeClaim)
+	}
+	if assert, ok := pc.Asserts["CreatePersistentVolumeClaim"]; ok {
+		return ret, assert(ret)
+	}
+	return ret, nil
+}
+
 func (pc PassClient) FindDeploymentConfigsByLabel(ns string, searchLabels map[string]string) ([]dcapi.DeploymentConfig, error) {
 	pc.Called["FindDeploymentConfigsByLabel"]++
 	if e, ok := pc.Error["FindDeploymentConfigsByLabel"]; ok {

--- a/pkg/openshift/client.go
+++ b/pkg/openshift/client.go
@@ -227,6 +227,16 @@ func (c Client) GetDeploymentConfigByName(ns, deploymentName string) (*dc.Deploy
 	return uptodate, nil
 }
 
+// CreatePersistentVolumeClaim uses the k8s api to setup the given claim
+func (c Client) CreatePersistentVolumeClaim(namespace string, claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {
+	pclaim, err := c.k8.PersistentVolumeClaims(namespace).Create(claim)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create PersistentVolumeClaim")
+	}
+	return pclaim, nil
+
+}
+
 // UpdateDeployConfigInNamespace updates the supplied deploy config in the supplied namespace and returns the deployconfig and any errors that occurred
 func (c Client) UpdateDeployConfigInNamespace(ns string, d *dc.DeploymentConfig) (*dc.DeploymentConfig, error) {
 	var deployed *dc.DeploymentConfig

--- a/pkg/openshift/template.go
+++ b/pkg/openshift/template.go
@@ -24,9 +24,9 @@ var PackagedTemplates = map[string]string{}
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 func init() {
-	packagedTemplates["cloudapp"] = templates.CloudAppTemplate
-	packagedTemplates["cache"] = templates.CacheTemplate
-	packagedTemplates["data"] = templates.DataTemplate
+	PackagedTemplates["cloudapp"] = templates.CloudAppTemplate
+	PackagedTemplates["cache"] = templates.CacheTemplate
+	PackagedTemplates["data"] = templates.DataTemplate
 }
 
 func (tl *templateLoaderDecoder) Load(name string) (*template.Template, error) {

--- a/pkg/openshift/template.go
+++ b/pkg/openshift/template.go
@@ -3,6 +3,7 @@ package openshift
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 
 	"github.com/openshift/origin/pkg/template/api"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -20,9 +21,12 @@ import (
 // PackagedTemplates map of locally stored templates
 var PackagedTemplates = map[string]string{}
 
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
 func init() {
-	PackagedTemplates["cloudapp"] = templates.CloudAppTemplate
-	PackagedTemplates["cache"] = templates.CacheTemplate
+	packagedTemplates["cloudapp"] = templates.CloudAppTemplate
+	packagedTemplates["cache"] = templates.CacheTemplate
+	packagedTemplates["data"] = templates.DataTemplate
 }
 
 func (tl *templateLoaderDecoder) Load(name string) (*template.Template, error) {
@@ -31,6 +35,20 @@ func (tl *templateLoaderDecoder) Load(name string) (*template.Template, error) {
 	t.Funcs(template.FuncMap{
 		"isEnd": func(n, total int) bool {
 			return n == total-1
+		},
+		"genPass": func() string {
+			b := make([]byte, 16)
+			for i := range b {
+				b[i] = letterBytes[rand.Intn(len(letterBytes))]
+			}
+			return string(b)
+		},
+		"isset": func(vals map[string]interface{}, key string) bool {
+			if nil == vals {
+				return false
+			}
+			_, ok := vals[key]
+			return ok
 		},
 	})
 	//check our own packagedTemplates first
@@ -65,7 +83,6 @@ func (tl *templateLoaderDecoder) Decode(data []byte) (*deploy.Template, error) {
 	dec := tl.decoder
 	obj, _, err := dec.Decode(data, nil, nil)
 	if err != nil {
-		fmt.Println(string(data))
 		return nil, errors.Wrap(err, "failed to decode template ")
 	}
 	tmpl, ok := obj.(*api.Template)

--- a/pkg/openshift/templates/cloudapp.json.tpl.go
+++ b/pkg/openshift/templates/cloudapp.json.tpl.go
@@ -78,7 +78,7 @@ var CloudAppTemplate = `
           "rhmap/project": "{{.ProjectGUID}}",
           "rhmap/title": "{{.ServiceName}}",
           "rhmap/type": "cloudapp",
-          "rhmap/name": "cloudapp"
+          "rhmap/name": "{{.ServiceName}}"
         },
         "annotations": {
           "description": "Defines how to build the application",

--- a/pkg/openshift/templates/data.json.tpl.go
+++ b/pkg/openshift/templates/data.json.tpl.go
@@ -1,0 +1,181 @@
+package templates
+
+var DataTemplate = `
+{{define "data"}}
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "mongodb",
+    "annotations": {
+      "description": "Mongodb",
+      "tags": "rhmap,mongodb"
+    }
+  },
+  "objects": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "data",
+        "labels": {
+          "name": "data",
+          "rhmap/domain": "{{.Domain}}",
+          "rhmap/env": "{{.Env}}",
+          "rhmap/title": "{{.ServiceName}}"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 27017,
+            "targetPort": 27017,
+            "nodePort": 0
+          }
+        ],
+        "selector": {
+          "name": "mongodb-replica"
+        },
+        "portalIP": "None",
+        "clusterIP": "None",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      }
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mongodb-claim-1",
+		"labels": {
+          "name": "data",
+          "rhmap/domain": "{{.Domain}}",
+          "rhmap/env": "{{.Env}}",
+          "rhmap/title": "{{.ServiceName}}"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+			{{if isset .Options "storage"}}  
+            "storage": "{{ index .Options "storage"}}"
+			{{else}}
+			"storage": "1Gi"
+			{{end}}
+          }
+        }
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mongodb-1",
+        "labels": {
+          "name": "mongodb",
+          "rhmap/domain": "{{.Domain}}",
+          "rhmap/env": "{{.Env}}",
+          "rhmap/title": "{{.ServiceName}}"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate"
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "replicas": 1,
+        "selector": {
+          "name": "mongodb-replica"
+        },
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "mongodb-replica"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "mongodb-data-volume",
+                "persistentVolumeClaim": {
+                  "claimName": "mongodb-claim-1"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "mongodb",
+                "image": "docker.io/rhmap/mongodb:centos-3.2-40",
+                "ports": [
+                  {
+                    "containerPort": 27017,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "MONGODB_REPLICA_NAME",
+                    "value": ""
+                  },
+                  {
+                    "name": "MONGODB_SERVICE_NAME",
+                    "value": "data"
+                  },
+                  {
+                    "name": "MONGODB_KEYFILE_VALUE",
+                    "value": "{{genPass}}"
+                  },
+                  {
+                    "name": "MONGODB_ADMIN_PASSWORD",
+                    "value":"{{genPass}}"
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": "1000m",
+                    "memory": "1000Mi"
+                  },
+                  "requests": {
+                    "cpu": "200m",
+                    "memory": "200Mi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "name": "mongodb-data-volume",
+                    "mountPath": "/var/lib/mongodb/data"
+                  }
+                ],
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent"
+              }
+            ],
+            "restartPolicy": "Always",
+            "dnsPolicy": "ClusterFirst"
+          }
+        }
+      }
+    }
+  ],
+  "labels": {
+    "template": "mongodb-core-single-template"
+  },
+  "params":[
+    {
+      "name": "storage",
+      "value": "1Gi",
+      "description": "The size of the volume for MongoDB Data",
+      "required": true
+    }
+  ]
+}
+{{end}}
+`


### PR DESCRIPTION
add mongodb as a service.

This adds a single node persistent mongo template that can be created as a service. 

To try this you can make the following request
```
http://<your_negotiator>/service/deploy/data/<your_env>

body:
{"serviceName":"data","domain":"rhmap", "replicas":1,"target":{"host":"YOUR_OPENSHIFT","token":"YOUR_TOKEN"}}

```