### PR TITLE
add Push UPS template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-VERSION := 0.0.7
+VERSION := 0.0.8
 NAME := negotiator
 
 # To build for a os you are not on, use:
@@ -27,7 +27,7 @@ build_services:
 	cd cmd/services && go build -ldflags "-X main.Version=v$(VERSION)"
 
 .PHONY: docker_build
-docker_build:
+docker_build: build
 	docker build -t feedhenry/negotiator:${VERSION} .
 
 .PHONY: docker_push

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,6 @@ go build .
 cd ..
 cd ..
 imagehash=`docker build -q .`
-docker tag $imagehash feedhenry/negotiator:0.0.7
+docker tag $imagehash feedhenry/negotiator:0.0.8
 oc deploy --latest negotiator 
 

--- a/os_template.json
+++ b/os_template.json
@@ -106,7 +106,7 @@
                 "spec": {
                     "containers": [{
                         "name": "negotiator",
-                        "image": "feedhenry/negotiator:0.0.7",
+                        "image": "feedhenry/negotiator:0.0.8",
                         "env": [],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",

--- a/pkg/deploy/template.go
+++ b/pkg/deploy/template.go
@@ -141,11 +141,10 @@ func (t Template) hasSecret() bool {
 }
 
 const templateCloudApp = "cloudapp"
-
 const templateCacheRedis = "cache-redis"
 const templateDataMongo = "data-mongo"
 const templateDataMysql = "data-mysql"
-
+const templatePushUps = "push-ups"
 
 type environmentServices []string
 
@@ -176,7 +175,6 @@ func (p Payload) Validate(template string) error {
 		if p.Repo == nil || p.Repo.Loc == "" || p.Repo.Ref == "" {
 			return ErrInvalid{message: "a repo is expected for a cloudapp"}
 		}
-
 	}
 	if p.Target == nil {
 		return ErrInvalid{message: "an oscp target is required"}
@@ -246,7 +244,7 @@ func (c Controller) Template(client Client, template, nameSpace string, payload 
 	}
 	osTemplate, err := c.TemplateDecoder.Decode(buf.Bytes())
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode into a os template: ")
+		return nil, errors.Wrap(err, "failed to decode into an os template: ")
 	}
 	searchCrit := map[string]string{"rhmap/name": payload.ServiceName}
 	if payload.CloudAppGUID != "" {

--- a/pkg/openshift/template.go
+++ b/pkg/openshift/template.go
@@ -25,13 +25,13 @@ const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456
 
 func init() {
 	PackagedTemplates["cloudapp"] = templates.CloudAppTemplate
-
 	PackagedTemplates["cache-redis"] = templates.CacheRedisTemplate
 	PackagedTemplates["data-mongo"] = templates.DataMongoTemplate
 	PackagedTemplates["data-mongo-replica"] = templates.DataMongoReplicaTemplate
 	PackagedTemplates["data-mongo-job"] = templates.DataMongoConfigJob
 	PackagedTemplates["data-mysql"] = templates.DataMySQLTemplate
 	PackagedTemplates["data-mysql-job"] = templates.DataMysqlConfigJob
+	PackagedTemplates["push-ups"] = templates.PushUPSTemplate
 }
 
 func (tl *templateLoaderDecoder) Load(name string) (*template.Template, error) {

--- a/pkg/openshift/templates/cache-redis.json.tpl.go
+++ b/pkg/openshift/templates/cache-redis.json.tpl.go
@@ -10,7 +10,7 @@ var CacheRedisTemplate = `
         "name": "Redis",
         "annotations": {
             "description": "Redis is an in-memory data structure store, used as a database, cache and message broker",
-            "dependenices": "None",
+            "dependencies": "None",
             "tags": "rhmap,redis"
         }
     },

--- a/pkg/openshift/templates/data-mongo.config_job.json.tpl.go
+++ b/pkg/openshift/templates/data-mongo.config_job.json.tpl.go
@@ -21,7 +21,7 @@ var DataMongoConfigJob = `
         "containers": [
           {
             "name": "datamongoconfig",
-            "image": "feedhenry/negotiator:0.0.7",
+            "image": "feedhenry/negotiator:0.0.8",
             "command": ["jobs",	
               "datamongoconfig",
 			  "--admin-user={{if isset . "admin-user"}}{{ index . "admin-user"}}{{end}}",

--- a/pkg/openshift/templates/data-mysql.config_job.json.tpl.go
+++ b/pkg/openshift/templates/data-mysql.config_job.json.tpl.go
@@ -22,7 +22,7 @@ var DataMysqlConfigJob = `
         "containers": [
           {
             "name": "datamysqlconfig",
-            "image": "feedhenry/negotiator:0.0.7",
+            "image": "feedhenry/negotiator:0.0.8",
             "command": ["jobs",	
               "datamysqlconfig",
               "--host={{if isset . "dbhost"}}{{ index . "dbhost"}}{{end}}",

--- a/pkg/openshift/templates/push-ups.json.tpl.go
+++ b/pkg/openshift/templates/push-ups.json.tpl.go
@@ -1,0 +1,170 @@
+package templates
+
+//PushUPSTemplate defines the template for deploying a push via UPS environment service to openshift 3
+var PushUPSTemplate = `
+{{define "push-ups"}}
+{
+  	"kind": "Template",
+  	"apiVersion": "v1",
+  	"metadata": {
+    	"name": "RHMAP UPS",
+    	"annotations": {
+      		"description": "RHMAP ups",
+			"dependencies": "data-mysql",
+      		"tags": "rhmap,mobile,nodejs",
+      		"iconClass": "icon-jboss"
+    	}
+  	},
+  	"objects": [{
+        "kind": "Route",
+        "apiVersion": "v1",
+        "metadata": {
+            "name": "push-ups",
+            "creationTimestamp": null,
+            "labels": {
+                "name": "push-ups"
+            },
+            "annotations": {
+                "openshift.io/host.generated": "true"
+            }
+        },
+        "spec": {
+            "host": "",
+            "to": {
+                "kind": "Service",
+                "name": "push-ups"
+            }
+        }
+    },
+	{
+			"kind": "Service",
+			"apiVersion": "v1",
+			"metadata": {
+				"name": "{{.ServiceName}}",
+				"labels": {
+					"name": "{{.ServiceName}}",
+					"rhmap/domain": "{{.Domain}}",
+					"rhmap/env": "{{.Env}}",
+					"rhmap/guid": "{{ generatedPass }}",
+					"rhmap/project": "{{.ProjectGUID}}",
+					"rhmap/name": "push-ups",
+					"rhmap/type": "environmentService"
+				}
+			},
+			"spec": {
+				"selector": {
+					"name": "{{.ServiceName}}"
+				},
+				"ports": [
+					{
+            			"port": 8080
+          			}
+        		]
+      		}
+    	},
+    	{
+			"kind": "DeploymentConfig",
+			"apiVersion": "v1",
+			"metadata": {
+				"kind":"DeploymentConfig",
+				"name": "{{.ServiceName}}",
+				"labels": {
+					"name": "{{.ServiceName}}",
+					"rhmap/domain": "{{.Domain}}",
+					"rhmap/env": "{{.Env}}",
+					"rhmap/guid": "{{ generatedPass }}",
+					"rhmap/project": "{{.ProjectGUID}}",
+					"rhmap/name": "push-ups",
+					"rhmap/type":"environmentService"
+				},
+				"annotations": {
+					"description": "Defines how to deploy the UPS push service"
+				}
+			},
+			"spec": {
+				"triggers": [
+					{
+						"type": "ConfigChange"
+					}
+				],
+				"replicas": 1,
+				"selector": {
+					"name": "{{.ServiceName}}"
+				},
+				"template": {
+					"metadata": {
+						"name": "{{.ServiceName}}",
+						"labels": {
+							"name": "{{.ServiceName}}",
+							"rhmap/domain": "{{.Domain}}",
+							"rhmap/env": "{{.Env}}",
+							"rhmap/guid": "{{ generatedPass }}",
+							"rhmap/project": "{{.ProjectGUID}}",
+							"rhmap/name": "push-ups",
+							"rhmap/type": "environmentService"
+						}
+					},
+          			"spec": {
+						"containers": [
+							{
+								"name": "{{.ServiceName}}",
+								"image": "docker.io/rhmap/unifiedpush-eap:1.1.4.Final-52",
+								"ports": [
+									{
+										"containerPort": 8443
+									},
+									{
+										"containerPort": 8080
+									},
+									{
+										"containerPort": 9990
+									}
+								],
+								"livenessProbe": {
+									"httpGet": {
+										"path": "/ag-push",
+										"port": 8080
+									},
+									"initialDelaySeconds": 600,
+									"timeoutSeconds": 5,
+									"periodSeconds": 60,
+									"successThreshold": 1,
+									"failureThreshold": 2
+								},
+								"readinessProbe": {
+									"httpGet": {
+										"path": "/ag-push",
+										"port": 8080
+									},
+									"initialDelaySeconds": 100,
+									"timeoutSeconds": 5,
+									"periodSeconds": 10,
+									"successThreshold": 1,
+									"failureThreshold": 1
+								},
+								"env": [
+									{
+										"name": "KEYCLOAK_BASE_URL",
+										"value": ""
+									}
+								],
+								"imagePullPolicy": "IfNotPresent",
+								"resources": {
+									"limits": {
+										"cpu": "2000m",
+										"memory": "5000Mi"
+									},
+									"requests": {
+										"cpu": "400m",
+										"memory": "900Mi"
+									}
+								}
+							}
+						]
+          			}
+        		}
+      		}
+    	}
+  	]
+}
+{{end}}`


### PR DESCRIPTION
to test:
- Deploy docker.io/feedhenry/negotiator:0.0.8 
- have data-mysql running in the environment
- execute this curl:
```bash
curl -X POST http://<negotiator>/service/deploy/push-ups/<env> -d '{"serviceName":"push-ups","domain":"<domain>", "replicas":1, "target":{"host":"<target>,"token":"<token>"}}'
```
- See UPS deploy successfully.