### PR TITLE
add support for configuring apps with ups push applications so the se…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-VERSION := 0.0.10
+VERSION := 0.0.11
 NAME := negotiator
 
 # To build for a os you are not on, use:

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,6 @@ cd ..
 cd ..
 cd cmd/jobs && go build . && cd ../..
 imagehash=`docker build -q .`
-docker tag $imagehash feedhenry/negotiator:0.0.9
+docker tag $imagehash feedhenry/negotiator:0.0.10
 oc deploy --latest negotiator
 

--- a/pkg/deploy/configuration.go
+++ b/pkg/deploy/configuration.go
@@ -78,6 +78,7 @@ func (cf *ConfigurationFactory) Factory(service string, config *Configuration, w
 			StatusPublisher: cf.StatusPublisher,
 			TemplateLoader:  cf.TemplateLoader,
 			logger:          cf.Logger,
+			PushLister:      DefaultPushLister,
 		}
 	}
 
@@ -182,7 +183,7 @@ func (cac *EnvironmentServiceConfigController) Configure(client Client, config *
 		cac.StatusPublisher.Publish(statusKey, configInProgress, "configuring "+serviceName)
 		configured[serviceName] = true
 		c := cac.ConfigurationFactory.Factory(serviceName, config, waitGroup)
-		c.Configure(client, deployment, namespace)
+		_, err := c.Configure(client, deployment, namespace)
 		if err != nil {
 			errs = append(errs, err.Error())
 		}
@@ -190,7 +191,7 @@ func (cac *EnvironmentServiceConfigController) Configure(client Client, config *
 	go func() {
 		waitGroup.Wait()
 		if _, err := client.UpdateDeployConfigInNamespace(namespace, deployment); err != nil {
-			cac.StatusPublisher.Publish(statusKey, configError, "failed to update DeployConfig after configuring it")
+			cac.StatusPublisher.Publish(statusKey, configError, "failed to update DeployConfig after configuring it "+err.Error())
 		}
 		if len(errs) > 0 {
 			cac.StatusPublisher.Publish(statusKey, configError, fmt.Sprintf(" some configuration jobs failed %v", errs))
@@ -198,24 +199,4 @@ func (cac *EnvironmentServiceConfigController) Configure(client Client, config *
 		cac.StatusPublisher.Publish(statusKey, configComplete, "service configuration complete")
 	}()
 	return nil
-}
-
-// PushUpsConfigure is an object for configuring push connection variables
-type PushUpsConfigure struct {
-	StatusPublisher StatusPublisher
-	TemplateLoader  TemplateLoader
-	logger          log.Logger
-	statusKey       string
-}
-
-func (p *PushUpsConfigure) statusUpdate(description, status string) {
-	if err := p.StatusPublisher.Publish(p.statusKey, status, description); err != nil {
-		p.logger.Error("failed to publish status ", err.Error())
-	}
-}
-
-// Configure the Push vars here
-func (p *PushUpsConfigure) Configure(client Client, deployment *dc.DeploymentConfig, namespace string) (*dc.DeploymentConfig, error) {
-
-	return deployment, nil
 }

--- a/pkg/deploy/ups_configure.go
+++ b/pkg/deploy/ups_configure.go
@@ -104,7 +104,7 @@ func (p *PushUpsConfigure) Configure(client Client, deployment *dc.DeploymentCon
 		return deployment, errors.Wrap(err, "failed to find ups-push DeploymentConfig")
 	}
 	if len(upsDcs) == 0 {
-		return deployment, errors.New("ups-push DeploymentConfig not found")
+		return deployment, errors.New("push-ups DeploymentConfig not found")
 	}
 	upsService, err := client.FindServiceByLabel(namespace, map[string]string{"rhmap/name": "push-ups"})
 	if err != nil || len(upsService) == 0 {

--- a/pkg/deploy/ups_configure.go
+++ b/pkg/deploy/ups_configure.go
@@ -1,0 +1,224 @@
+package deploy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"time"
+
+	"github.com/feedhenry/negotiator/pkg/log"
+	dc "github.com/openshift/origin/pkg/deploy/api"
+	"github.com/pkg/errors"
+	k8api "k8s.io/kubernetes/pkg/api"
+)
+
+// PushUpsConfigure is an object for configuring push connection variables
+type PushUpsConfigure struct {
+	StatusPublisher StatusPublisher
+	TemplateLoader  TemplateLoader
+	logger          log.Logger
+	statusKey       string
+	PushLister      func(host, user, password string) ([]*PushApplication, error)
+}
+
+func (p *PushUpsConfigure) statusUpdate(description, status string) {
+	if err := p.StatusPublisher.Publish(p.statusKey, status, description); err != nil {
+		p.logger.Error("failed to publish status ", err.Error())
+	}
+}
+
+// DefaultPushLister list PushApplications from ups
+var DefaultPushLister = func(host, user, password string) ([]*PushApplication, error) {
+	hc := http.Client{}
+	hc.Timeout = time.Second * 10
+	form := url.Values{}
+	form.Add("grant_type", "password")
+	form.Add("username", user)
+	form.Add("password", password)
+	form.Add("client_id", "unified-push-server-js")
+
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/auth/realms/aerogear/protocol/openid-connect/token", host), strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to listPushApplications ")
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to make request to listPushApplications ")
+	}
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read body listPushApplications ")
+	}
+	payload := map[string]interface{}{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, errors.Wrap(err, "failed to Unmarshal listPushApplications ")
+	}
+	token := payload["access_token"].(string)
+
+	req, err = http.NewRequest("GET", fmt.Sprintf("%s/ag-push/rest/applications", host), nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create request listPushApplications ")
+	}
+	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Content-type", "application/json")
+	resp, err = hc.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to make request to listPushApplications ")
+	}
+	defer resp.Body.Close()
+	data, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read response listPushApplications ")
+	}
+	apps := []*PushApplication{}
+	if err := json.Unmarshal(data, &apps); err != nil {
+		return nil, errors.Wrap(err, "failed to Unmarshal listPushApplications ")
+	}
+
+	return apps, nil
+}
+
+type PushApplication struct {
+	PushApplicationID string `json:"pushApplicationID"`
+	MasterSecret      string `json:"masterSecret"`
+	Name              string `json:"name"`
+}
+
+// Configure the Push vars here
+func (p *PushUpsConfigure) Configure(client Client, deployment *dc.DeploymentConfig, namespace string) (*dc.DeploymentConfig, error) {
+	pushConfigPath := "/opt/rh/push-config"
+	// find the push route
+	route, err := client.FindRouteByName(namespace, "push-ups")
+	if err != nil {
+		return deployment, errors.Wrap(err, "failed to find route in Configure ")
+	}
+	p.StatusPublisher.Publish(p.statusKey, configInProgress, "found ups route")
+	upsDcs, err := client.FindDeploymentConfigsByLabel(namespace, map[string]string{"rhmap/name": "push-ups"})
+	if err != nil {
+		return deployment, errors.Wrap(err, "failed to find ups-push DeploymentConfig")
+	}
+	if len(upsDcs) == 0 {
+		return deployment, errors.New("ups-push DeploymentConfig not found")
+	}
+	upsService, err := client.FindServiceByLabel(namespace, map[string]string{"rhmap/name": "push-ups"})
+	if err != nil || len(upsService) == 0 {
+		if err != nil {
+			return deployment, errors.Wrap(err, "failed to FindServiceByLabel during PushUpsConfigure "+err.Error())
+		}
+		return deployment, errors.New("failed to FindServiceByLabel during PushUpsConfigure")
+	}
+
+	p.StatusPublisher.Publish(p.statusKey, configInProgress, "found ups deployment")
+	configMap, err := client.FindConfigMapByName(namespace, "ups-client-config")
+	if err != nil {
+		return deployment, errors.Wrap(err, "failed to FindConfigMapByName in PushUpsConfigure")
+	}
+	p.StatusPublisher.Publish(p.statusKey, configInProgress, "found ups client configMap")
+	var user, pass string
+	env := upsDcs[0].Spec.Template.Spec.Containers[0].Env
+	for _, e := range env {
+		if e.Name == "ADMIN_USER" {
+			user = e.Value
+		}
+		if e.Name == "ADMIN_PASSWORD" {
+			pass = e.Value
+		}
+	}
+	p.StatusPublisher.Publish(p.statusKey, configInProgress, "found ups user pass "+user+":"+pass)
+	//TODO if tls is edge switch to https
+	host := "%s%s"
+	if route.Spec.TLS == nil {
+		host = fmt.Sprintf(host, "http://", route.Spec.Host)
+	} else {
+		host = fmt.Sprintf(host, "https://", route.Spec.Host)
+	}
+	apps, err := p.PushLister(host, user, pass)
+	if err != nil {
+		return deployment, errors.Wrap(err, "failed PushLister in PushUpsConfigure")
+	}
+	p.StatusPublisher.Publish(p.statusKey, configInProgress, fmt.Sprintf("found ups apps %v", len(apps)))
+	configmapData := map[string]string{}
+	appsMap := map[string]*PushApplication{}
+	for _, a := range apps {
+		appsMap[a.Name] = a
+	}
+	data, err := json.Marshal(appsMap)
+	configmapData["config.json"] = string(data)
+	configMap.Data = configmapData
+	if _, err := client.UpdateConfigMap(namespace, configMap); err != nil {
+		return deployment, errors.Wrap(err, "failed to UpdateConfigMap in PushUpsConfigure")
+	}
+	p.StatusPublisher.Publish(p.statusKey, configInProgress, "updated ups configmap")
+	//check if volume already exists
+	volumeFound := false
+	for _, v := range deployment.Spec.Template.Spec.Volumes {
+		if v.Name == "push-config-volume" {
+			volumeFound = true
+			break
+		}
+	}
+	// update env var for ups service
+	for i := range deployment.Spec.Template.Spec.Containers {
+		upsEnvFound := false
+		pushPathFound := false
+		for ie, e := range deployment.Spec.Template.Spec.Containers[i].Env {
+			if e.Name == "UPS_SERVICE_HOST" { // dunno if we need these as kubernetes injects them
+				deployment.Spec.Template.Spec.Containers[i].Env[ie].Value = upsService[0].Name
+				upsEnvFound = true
+			}
+			if e.Name == "UPS_CONFIG_PATH" {
+				pushPathFound = true
+			}
+		}
+		if !upsEnvFound {
+			deployment.Spec.Template.Spec.Containers[i].Env = append(deployment.Spec.Template.Spec.Containers[i].Env, k8api.EnvVar{
+				Name:  "UPS_SERVICE_HOST",
+				Value: "push-ups",
+			})
+		}
+		if !pushPathFound {
+			deployment.Spec.Template.Spec.Containers[i].Env = append(deployment.Spec.Template.Spec.Containers[i].Env, k8api.EnvVar{
+				Name:  "UPS_CONFIG_PATH",
+				Value: pushConfigPath + "/config.json",
+			})
+		}
+	}
+	// if we found the volume we are done
+	if volumeFound {
+		return deployment, nil
+	}
+
+	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, k8api.Volume{
+		Name: "push-config-volume",
+		VolumeSource: k8api.VolumeSource{
+			ConfigMap: &k8api.ConfigMapVolumeSource{
+				LocalObjectReference: k8api.LocalObjectReference{Name: "ups-client-config"},
+			},
+		},
+	})
+	for i := range deployment.Spec.Template.Spec.Containers {
+		vmounts := deployment.Spec.Template.Spec.Containers[i].VolumeMounts
+		vmFound := false
+		for _, vm := range vmounts {
+			if vm.Name == "push-config-volume" {
+				vmFound = true
+				break
+			}
+		}
+		if !vmFound {
+			deployment.Spec.Template.Spec.Containers[i].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[i].VolumeMounts, k8api.VolumeMount{
+				Name:      "push-config-volume",
+				MountPath: pushConfigPath,
+				ReadOnly:  true,
+			})
+		}
+	}
+
+	return deployment, nil
+}

--- a/pkg/deploy/ups_configure_test.go
+++ b/pkg/deploy/ups_configure_test.go
@@ -1,0 +1,197 @@
+package deploy_test
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/feedhenry/negotiator/pkg/deploy"
+	"github.com/feedhenry/negotiator/pkg/mock"
+	"github.com/feedhenry/negotiator/pkg/openshift"
+	dcapi "github.com/openshift/origin/pkg/deploy/api"
+	route "github.com/openshift/origin/pkg/route/api"
+)
+
+func TestUPSConfigure(t *testing.T) {
+	tl := openshift.NewTemplateLoaderDecoder("../openshift/templates/")
+	msp := &mockStatusPublisher{}
+	logger := logrus.StandardLogger()
+	factory := deploy.ConfigurationFactory{
+		StatusPublisher: msp,
+		Logger:          logger,
+		TemplateLoader:  tl,
+	}
+
+	deployingConfig := func() dcapi.DeploymentConfig {
+		return dcapi.DeploymentConfig{
+			ObjectMeta: api.ObjectMeta{
+				Name: "test",
+				Labels: map[string]string{
+					"rhmap/guid": "",
+				},
+			},
+			Spec: dcapi.DeploymentConfigSpec{
+				Template: &api.PodTemplateSpec{
+					Spec: api.PodSpec{
+						Containers: []api.Container{{
+							Name: "",
+							Env: []api.EnvVar{{
+								Name:  "test",
+								Value: "test",
+							}},
+						}},
+					},
+				},
+			},
+		}
+	}
+	//setup the MySQL DeploymentConfig fresh for each test
+	UPSdc := func() []dcapi.DeploymentConfig {
+		return []dcapi.DeploymentConfig{
+			{
+				ObjectMeta: api.ObjectMeta{
+					Name: "push-ups",
+					Labels: map[string]string{
+						"rhmap/guid": "asdasdasdassdasdasdsadasdadasdasdasdasdsda",
+					},
+				},
+				Spec: dcapi.DeploymentConfigSpec{
+					Template: &api.PodTemplateSpec{
+						Spec: api.PodSpec{
+							Containers: []api.Container{{
+								Name: "",
+								Env: []api.EnvVar{
+									{
+										Name:  "ADMIN_USER",
+										Value: "admin",
+									},
+									{
+										Name:  "ADMIN_PASSWORD",
+										Value: "123",
+									},
+								},
+							}},
+						},
+					},
+				}},
+		}
+	}
+	UPSsvc := func() []api.Service {
+
+		return []api.Service{
+			{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{
+						"rhmap/name": "push-ups",
+						"rhmap/guid": "asdasdasdassdasdasdsadasdadasdasdasdasdsda",
+					},
+				},
+			},
+		}
+	}
+
+	UPSRoute := func() route.Route {
+		return route.Route{
+			ObjectMeta: api.ObjectMeta{Name: "push-ups"},
+			Spec: route.RouteSpec{
+				Host: "http://ups.pushy.com",
+			},
+		}
+	}
+
+	cases := []struct {
+		Name          string
+		ExpectError   bool
+		UPSDC         func() []dcapi.DeploymentConfig
+		UPSSvc        func() []api.Service
+		UPSRoute      func() route.Route
+		DcToConfigure func() *dcapi.DeploymentConfig
+		Namespace     string
+		AssertDC      func(t *testing.T, dc *dcapi.DeploymentConfig)
+		Calls         map[string]int
+		PushLister    func(host, user, pass string) ([]*deploy.PushApplication, error)
+	}{
+		{
+			Name:        "test ups configure happy",
+			ExpectError: false,
+			UPSDC:       UPSdc,
+			UPSSvc:      UPSsvc,
+			UPSRoute:    UPSRoute,
+			PushLister: func(host, user, pass string) ([]*deploy.PushApplication, error) {
+
+				return []*deploy.PushApplication{
+					&deploy.PushApplication{
+						Name:              "testapp",
+						MasterSecret:      "secret",
+						PushApplicationID: "id",
+					},
+				}, nil
+			},
+			DcToConfigure: func() *dcapi.DeploymentConfig {
+				dc := deployingConfig()
+				return &dc
+			},
+			Namespace: "test",
+			AssertDC: func(t *testing.T, dc *dcapi.DeploymentConfig) {
+				if nil == dc {
+					t.Fatalf("did not expect the DeploymentConfig to nil")
+				}
+				vmounts := dc.Spec.Template.Spec.Containers[0].VolumeMounts
+				volumes := dc.Spec.Template.Spec.Volumes
+				if len(vmounts) != 1 {
+					t.Fatalf("expected 1 volume mount but got %v", len(vmounts))
+				}
+				if vmounts[0].Name != volumes[0].Name {
+					t.Fatalf("expected to get %s but got %s ", volumes[0].Name, vmounts[0].Name)
+				}
+				if len(volumes) != 1 {
+					t.Fatalf("expected 1 volume but got %v ", len(volumes))
+				}
+				upsServiceEnv := false
+				upsConfigEnv := false
+				for _, e := range dc.Spec.Template.Spec.Containers[0].Env {
+					if e.Name == "UPS_SERVICE_HOST" {
+						upsServiceEnv = true
+					}
+					if e.Name == "UPS_CONFIG_PATH" {
+						upsConfigEnv = true
+					}
+				}
+				if !upsConfigEnv || !upsServiceEnv {
+					t.Fatalf("missing env var expected to find UPS_CONFIG_PATH and UPS_SERVICE_HOST")
+				}
+			},
+			Calls: map[string]int{
+				"FindDeploymentConfigsByLabel": 1,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			client := mock.NewPassClient()
+			client.Returns["FindDeploymentConfigsByLabel"] = tc.UPSDC()
+
+			configure := factory.Factory("push-ups", &deploy.Configuration{InstanceID: "instanceID", Action: "provision"}, &sync.WaitGroup{})
+			pConfigure := configure.(*deploy.PushUpsConfigure)
+			pConfigure.PushLister = tc.PushLister
+			deployed, err := pConfigure.Configure(client, tc.DcToConfigure(), tc.Namespace)
+			if tc.ExpectError && err == nil {
+				t.Fatalf("expected an error but got none")
+			}
+			if !tc.ExpectError && err != nil {
+				t.Fatalf("did not expect an error but got %s ", err.Error())
+			}
+			for f, n := range tc.Calls {
+				if n != client.CalledTimes(f) {
+					t.Errorf("Expected %s to be called %d times, it was called %d times", f, n, client.CalledTimes(f))
+				}
+			}
+			tc.AssertDC(t, deployed)
+		})
+	}
+
+}

--- a/pkg/deploy/ups_configure_test.go
+++ b/pkg/deploy/ups_configure_test.go
@@ -174,6 +174,7 @@ func TestUPSConfigure(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			client := mock.NewPassClient()
 			client.Returns["FindDeploymentConfigsByLabel"] = tc.UPSDC()
+			client.Returns["FindServiceByLabel"] = tc.UPSSvc()
 
 			configure := factory.Factory("push-ups", &deploy.Configuration{InstanceID: "instanceID", Action: "provision"}, &sync.WaitGroup{})
 			pConfigure := configure.(*deploy.PushUpsConfigure)

--- a/pkg/mock/paasClient.go
+++ b/pkg/mock/paasClient.go
@@ -62,6 +62,54 @@ func (pc PassClient) CreateJobToWatch(j *batch.Job, ns string) (watch.Interface,
 	return watch.NewEmptyWatch(), nil
 }
 
+func (pc PassClient) FindRouteByName(ns, name string) (*roapi.Route, error) {
+	pc.Called["FindRouteByName"]++
+	if e, ok := pc.Error["FindRouteByName"]; ok {
+		return nil, e
+	}
+	var ret = &roapi.Route{}
+	if pc.Returns["FindRouteByName"] != nil {
+		ret = pc.Returns["FindRouteByName"].(*roapi.Route)
+	}
+	return ret, nil
+}
+
+func (pc PassClient) FindConfigMapByName(ns, name string) (*api.ConfigMap, error) {
+	pc.Called["FindConfigMapByName"]++
+	if e, ok := pc.Error["FindConfigMapByName"]; ok {
+		return nil, e
+	}
+	var ret = &api.ConfigMap{}
+	if pc.Returns["FindConfigMapByName"] != nil {
+		ret = pc.Returns["FindConfigMapByName"].(*api.ConfigMap)
+	}
+	return ret, nil
+}
+
+func (pc PassClient) CreateConfigMap(ns string, cm *api.ConfigMap) (*api.ConfigMap, error) {
+	pc.Called["CreateConfigMap"]++
+	if e, ok := pc.Error["CreateConfigMap"]; ok {
+		return nil, e
+	}
+	var ret = &api.ConfigMap{}
+	if pc.Returns["CreateConfigMap"] != nil {
+		ret = pc.Returns["CreateConfigMap"].(*api.ConfigMap)
+	}
+	return ret, nil
+}
+
+func (pc PassClient) UpdateConfigMap(ns string, cm *api.ConfigMap) (*api.ConfigMap, error) {
+	pc.Called["UpdateConfigMap"]++
+	if e, ok := pc.Error["UpdateConfigMap"]; ok {
+		return nil, e
+	}
+	var ret = &api.ConfigMap{}
+	if pc.Returns["UpdateConfigMap"] != nil {
+		ret = pc.Returns["UpdateConfigMap"].(*api.ConfigMap)
+	}
+	return ret, nil
+}
+
 func (pc PassClient) FindServiceByLabel(ns string, searchLabels map[string]string) ([]api.Service, error) {
 	pc.Called["FindServiceByLabel"]++
 	if e, ok := pc.Error["FindServiceByLabel"]; ok {

--- a/pkg/openshift/templates/data-mysql.config_job.json.tpl.go
+++ b/pkg/openshift/templates/data-mysql.config_job.json.tpl.go
@@ -22,7 +22,7 @@ var DataMysqlConfigJob = `
         "containers": [
           {
             "name": "datamysqlconfig",
-            "image": "feedhenry/negotiator:0.0.10",
+            "image": "feedhenry/negotiator:0.0.11",
             "command": ["jobs",
               "datamysqlconfig",
               "--host={{if isset . "dbhost"}}{{ index . "dbhost"}}{{end}}",

--- a/pkg/openshift/templates/push-ups.json.tpl.go
+++ b/pkg/openshift/templates/push-ups.json.tpl.go
@@ -15,7 +15,17 @@ var PushUPSTemplate = `
       		"iconClass": "icon-jboss"
     	}
   	},
-  	"objects": [{
+  	"objects": [
+	{
+      "kind": "ConfigMap",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "ups-client-config"
+      },
+      "data": {
+      }
+    },
+	{
         "kind": "Route",
         "apiVersion": "v1",
         "metadata": {
@@ -143,6 +153,14 @@ var PushUPSTemplate = `
 									"failureThreshold": 1
 								},
 								"env": [
+									{
+										"name":"ADMIN_USER",
+										"value":"admin"
+									},
+									{
+										"name":"ADMIN_PASSWORD",
+										"value":"123"
+									},
 									{
 										"name": "KEYCLOAK_BASE_URL",
 										"value": ""


### PR DESCRIPTION
…rver side can send push

So the implementation here follows the following pattern. When a cloud app is deployed to an environment, negotiator asks UPS for a list of push applications. It then writes these to a configmap and mounts them into the cloud app for it to use. 
If a new push app is created then the app will need to be redeployed to pick up the changes.

I have tested I can read the config map from the cloud app but haven't yet tried with a real app. 

Longer term it would make sense to have negotiator create a separate user in UPS as currently we are using the admin user

ping @philbrookes 